### PR TITLE
Alspac mongo config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,15 @@ The backup is done as follows:
 	    files: [/folder/*.csv,/folder/toto.sh]
 	    folders: [/var/www/mica.org]
 	    mongodbs:
+	      names: [mica_data] #Comma seperated list of database names
+	      #Assume all databases have the same connection and security settings
 	      host: localhost
 	      port: 27017
+	      usr: micaadmin
+	      pwd: '1234'
+      	      authenticationDatabase: admin #The mongo database used to authenticate users
+              output: archive #Dump to a single archive file (comment out to dump to folder)
+              sslPEMKeyFile: /path/to/PEMkeyFile #Comment out if SSL is not required	      
 	    databases:
 	      names: [mica]
 	      usr: dbadmin


### PR DESCRIPTION
Added additional config options for backing up MongoDBs:
usr: micaadmin #User with correct permissons to perform mongodump
pwd: 'Password' #Password of the above user
authenticationDatabase: admin #The mongo database used to authenticate users
output: archive #Dump to a single archive file (comment out to dump to folder)
sslPEMKeyFile: /path/to/PEMkeyFile #Comment out if SSL is not required

Note: Process assumes all databases have the same connection and security settings. If there are different usernames and passwords for each database then a separate config project is required for each database.