### PR TITLE
Update the project folder structure to allow files and sub folders to be excluded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ The backup is done as follows:
 	      usr: dbadmin
 	      pwd: '123456'
 	  opal:
-	    folders: [/var/lib/opal/,/var/log/opal/]
+	    folders: # Instead of simple list, all folders can be specified with a path and zero or more excluded subfolders
+	      - folder:
+		path: /var/my/folder
+		excludes: [toto,tata]  # must be relative paths and cannot start with wildcards
+	      - folder:
+		path: /etc/my/folder
 	    databases:
 	      names: [opal_key,opal_data]
 	      usr: dbadmin

--- a/obiba/src/main/python/backup.conf
+++ b/obiba/src/main/python/backup.conf
@@ -13,8 +13,13 @@ projects:
     keep:
       days: 1
       month: 1
-    files: [/tmp/toto.txt, /tmp/backuptest/toto.txt]
-    folders: [/tmp/backuptest/folder1,/tmp/backuptest/folder2, /tmp/backuptest/folder3/folder1]
+    files: [/tmp/toto.txt, /tmp/b_test/toto.txt]
+    folders: 
+      - folder:
+          path: /tmp/backupstest/folder1
+          excludes: [exclude_folder,exclude_file.txt]
+      - folder:
+          path: /tmp/backupstest/folder2
     databases:
       prefix: 'live%'
       usr: zorro

--- a/obiba/src/main/python/backup.py
+++ b/obiba/src/main/python/backup.py
@@ -165,17 +165,29 @@ class ObibaBackup:
 
     ####################################################################################################################
     def __backupFolders(self, folders, destination):
-        for folder in folders:
-            print "\tBacking up folder %s to %s" % (folder, destination)
-            filename = "%s.tar.gz" % (os.path.basename(folder))
-            destinationPath = os.path.join(destination, folder[1:])
-            if not os.path.exists(destinationPath):
-              os.makedirs(destinationPath)
-            backupFile = os.path.join(destinationPath, filename)
-            result = call(["tar", "czfP", backupFile, folder])
-            if result != 0:
-                print "Failed to tar %s" % backupFile
-
+        for folder_item in folders:
+            if 'folder' in folder_item:
+                if 'path' in folder_item['folder']:
+                    folder_path = folder_item['folder']['path']
+                    print "\tBacking up folder %s to %s" % (folder_path, destination)
+                    filename = "%s.tar.gz" % (os.path.basename(folder_path))
+                    
+                    excludes = []
+                    if 'excludes' in folder_item['folder']:
+                        for exclude in folder_item['folder']['excludes']:
+                            if not (os.path.exists(exclude) or os.path.exists(os.path.join(folder_path,exclude))):
+                                print "\tExclude path %s not found, check the config entry is correct" % exclude 
+                            excludes.append('--exclude=%s' % exclude)
+                            
+                    destinationPath = os.path.join(destination, folder_path[1:])
+                    if not os.path.exists(destinationPath):
+                      os.makedirs(destinationPath)
+                    backupFile = os.path.join(destinationPath, filename)
+                    #print ' '.join(str(x) for x in ["tar", "czfP", backupFile, folder_path] + excludes)
+                    result = call(["tar", "czfP", backupFile, folder_path] + excludes) 
+                    if result != 0:
+                        print "Failed to tar %s" % backupFile
+                        
     ####################################################################################################################
     def __backupMongodbs(self, mongodbs, destination):
         #Build the mongodump command based on the config. Config file struture assumes settings are the same for all databases

--- a/obiba/src/main/python/backup.py
+++ b/obiba/src/main/python/backup.py
@@ -166,27 +166,32 @@ class ObibaBackup:
     ####################################################################################################################
     def __backupFolders(self, folders, destination):
         for folder_item in folders:
+            excludes = []
             if 'folder' in folder_item:
+                #Using hierarchical folder structure 
                 if 'path' in folder_item['folder']:
                     folder_path = folder_item['folder']['path']
-                    print "\tBacking up folder %s to %s" % (folder_path, destination)
-                    filename = "%s.tar.gz" % (os.path.basename(folder_path))
                     
-                    excludes = []
                     if 'excludes' in folder_item['folder']:
                         for exclude in folder_item['folder']['excludes']:
                             if not (os.path.exists(exclude) or os.path.exists(os.path.join(folder_path,exclude))):
                                 print "\tExclude path %s not found, check the config entry is correct" % exclude 
                             excludes.append('--exclude=%s' % exclude)
+            else:
+                #Using simple folder list
+                folder_path = folder_item
+                
+            print "\tBacking up folder %s to %s" % (folder_path, destination)
+            filename = "%s.tar.gz" % (os.path.basename(folder_path))
                             
-                    destinationPath = os.path.join(destination, folder_path[1:])
-                    if not os.path.exists(destinationPath):
-                      os.makedirs(destinationPath)
-                    backupFile = os.path.join(destinationPath, filename)
-                    #print ' '.join(str(x) for x in ["tar", "czfP", backupFile, folder_path] + excludes)
-                    result = call(["tar", "czfP", backupFile, folder_path] + excludes) 
-                    if result != 0:
-                        print "Failed to tar %s" % backupFile
+            destinationPath = os.path.join(destination, folder_path[1:])
+            if not os.path.exists(destinationPath):
+              os.makedirs(destinationPath)
+            backupFile = os.path.join(destinationPath, filename)
+            #print ' '.join(str(x) for x in ["tar", "czfP", backupFile, folder_path] + excludes)
+            result = call(["tar", "czfP", backupFile, folder_path] + excludes) 
+            if result != 0:
+                print "Failed to tar %s" % backupFile
                         
     ####################################################################################################################
     def __backupMongodbs(self, mongodbs, destination):


### PR DESCRIPTION
The config settings for this are now the same as the rsyncs folders. 

Note The exclude syntax of tar seems to have changed between 1.1x and 1.2. The exclude option may not work for version of tar before 1.2. https://unix.stackexchange.com/questions/32845/tar-exclude-doesnt-exclude-why

If have only tested this on Centos 7